### PR TITLE
Fix crash when resource-pack-id is blank in server.properties

### DIFF
--- a/src/main/java/org/scubakay/dynamic_resource_pack/config/ServerProperties.java
+++ b/src/main/java/org/scubakay/dynamic_resource_pack/config/ServerProperties.java
@@ -9,7 +9,6 @@ import org.scubakay.dynamic_resource_pack.DynamicResourcePack;
 
 import java.util.Objects;
 import java.util.Optional;
-import java.util.UUID;
 
 public class ServerProperties {
     public ConfigEntry<String> id;
@@ -19,7 +18,7 @@ public class ServerProperties {
     public ConfigEntry<String> prompt;
 
     public ServerProperties(ConfigBuilder builder) {
-        id = builder.entry("resource-pack-id", UUID.randomUUID().toString());
+        id = builder.entry("resource-pack-id", "");
         url = builder.stringEntry("resource-pack", "");
         hash = builder.stringEntry("resource-pack-sha1", "");
         required = builder.booleanEntry("require-resource-pack", false);

--- a/src/main/java/org/scubakay/dynamic_resource_pack/config/ServerProperties.java
+++ b/src/main/java/org/scubakay/dynamic_resource_pack/config/ServerProperties.java
@@ -12,14 +12,14 @@ import java.util.Optional;
 import java.util.UUID;
 
 public class ServerProperties {
-    public ConfigEntry<UUID> id;
+    public ConfigEntry<String> id;
     public ConfigEntry<String> url;
     public ConfigEntry<String> hash;
     public ConfigEntry<Boolean> required;
     public ConfigEntry<String> prompt;
 
     public ServerProperties(ConfigBuilder builder) {
-        id = builder.entry("resource-pack-id", UUID.randomUUID());
+        id = builder.entry("resource-pack-id", UUID.randomUUID().toString());
         url = builder.stringEntry("resource-pack", "");
         hash = builder.stringEntry("resource-pack-sha1", "");
         required = builder.booleanEntry("require-resource-pack", false);

--- a/src/main/java/org/scubakay/dynamic_resource_pack/config/ServerProperties.java
+++ b/src/main/java/org/scubakay/dynamic_resource_pack/config/ServerProperties.java
@@ -7,8 +7,10 @@ import net.minecraft.text.Text;
 import org.jetbrains.annotations.NotNull;
 import org.scubakay.dynamic_resource_pack.DynamicResourcePack;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 
 public class ServerProperties {
     public ConfigEntry<String> id;
@@ -41,6 +43,14 @@ public class ServerProperties {
                 DynamicResourcePack.LOGGER.error("Failed to parse prompt text " + promptString, e);
                 return Optional.empty();
             }
+        }
+    }
+
+    public UUID getUUID() {
+        if (this.id.get().isEmpty()) {
+            return UUID.nameUUIDFromBytes(this.url.get().getBytes(StandardCharsets.UTF_8));
+        } else {
+            return UUID.fromString(this.id.get());
         }
     }
 

--- a/src/main/java/org/scubakay/dynamic_resource_pack/config/ServerProperties.java
+++ b/src/main/java/org/scubakay/dynamic_resource_pack/config/ServerProperties.java
@@ -20,7 +20,7 @@ public class ServerProperties {
     public ConfigEntry<String> prompt;
 
     public ServerProperties(ConfigBuilder builder) {
-        id = builder.entry("resource-pack-id", "");
+        id = builder.stringEntry("resource-pack-id", "");
         url = builder.stringEntry("resource-pack", "");
         hash = builder.stringEntry("resource-pack-sha1", "");
         required = builder.booleanEntry("require-resource-pack", false);

--- a/src/main/java/org/scubakay/dynamic_resource_pack/util/ConfigFileHandler.java
+++ b/src/main/java/org/scubakay/dynamic_resource_pack/util/ConfigFileHandler.java
@@ -14,7 +14,6 @@ import org.scubakay.dynamic_resource_pack.DynamicResourcePack;
 import org.scubakay.dynamic_resource_pack.config.ServerProperties;
 
 import java.nio.file.Path;
-import java.util.UUID;
 
 /**
  * Responsible for keeping track of the ServerProperties file
@@ -43,7 +42,7 @@ public class ConfigFileHandler {
 
     public ResourcePackSendS2CPacket getResourcePackSendS2CPacket() {
         return new ResourcePackSendS2CPacket(
-                UUID.fromString(serverProperties.id.get()),
+                serverProperties.getUUID(),
                 serverProperties.url.get(),
                 serverProperties.hash.get(),
                 serverProperties.required.get(),

--- a/src/main/java/org/scubakay/dynamic_resource_pack/util/ConfigFileHandler.java
+++ b/src/main/java/org/scubakay/dynamic_resource_pack/util/ConfigFileHandler.java
@@ -14,6 +14,7 @@ import org.scubakay.dynamic_resource_pack.DynamicResourcePack;
 import org.scubakay.dynamic_resource_pack.config.ServerProperties;
 
 import java.nio.file.Path;
+import java.util.UUID;
 
 /**
  * Responsible for keeping track of the ServerProperties file
@@ -42,7 +43,7 @@ public class ConfigFileHandler {
 
     public ResourcePackSendS2CPacket getResourcePackSendS2CPacket() {
         return new ResourcePackSendS2CPacket(
-                serverProperties.id.get(),
+                UUID.fromString(serverProperties.id.get()),
                 serverProperties.url.get(),
                 serverProperties.hash.get(),
                 serverProperties.required.get(),


### PR DESCRIPTION
Loads resource-pack-id (UUID) as a string that's empty by default, same as the other options. For the packet, if the id is missing, it will create one from the resource pack URL, same as vanilla