### PR TITLE
Add config option for whether /reload should be ran

### DIFF
--- a/src/main/java/org/scubakay/dynamic_resource_pack/config/ModConfig.java
+++ b/src/main/java/org/scubakay/dynamic_resource_pack/config/ModConfig.java
@@ -7,10 +7,12 @@ public class ModConfig {
     public ConfigEntry<String> reloadResourcePackMessage;
     public ConfigEntry<String> reloadResourcePackAction;
     public ConfigEntry<String> reloadResourcePackTooltip;
+    public ConfigEntry<Boolean> runReloadOnResourcePackUpdate;
 
     public ModConfig(ConfigBuilder builder) {
         reloadResourcePackMessage = builder.entry("reload-resourcepack-message", "A new version of the server resource pack is available: ").comment("The message sent to players notifying them of a new version");
         reloadResourcePackAction = builder.entry("reload-resourcepack-action", "[Reload]").comment("The text of the reload 'button' in the notification message");
         reloadResourcePackTooltip = builder.entry("reload-resourcepack-tooltip", "Reload the server resource pack").comment("The tooltip on the reload 'button' in the notification message");
+        runReloadOnResourcePackUpdate = builder.entry("run-reload-on-resource-pack-update", true).comment("If /reload should be ran when the resource pack is updated");
     }
 }

--- a/src/main/java/org/scubakay/dynamic_resource_pack/util/ConfigFileHandler.java
+++ b/src/main/java/org/scubakay/dynamic_resource_pack/util/ConfigFileHandler.java
@@ -78,7 +78,9 @@ public class ConfigFileHandler {
             DynamicResourcePack.LOGGER.info("{} has changed, reloading resource pack...", getConfigFile(server).getFileName());
             serverProperties = newConfig;
 
-            reloadDatapacks();
+            if (DynamicResourcePack.modConfig.runReloadOnResourcePackUpdate.get()) {
+                reloadDatapacks();
+            }
             notifyPlayers();
         }
     }


### PR DESCRIPTION
Some mods get weird when /reload is ran, so being able to disable it would be nice. As far as I'm aware datapacks are mostly only useful for resource pack stuff when you're adding custom music discs and the like, which isn't always the case, so being able to turn it off should be fine.