### PR TITLE
Add support for 1.21.X

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,12 +48,14 @@ dependencies {
 processResources {
     inputs.property "version", project.version
     inputs.property "minecraft_version", project.minecraft_version
+    inputs.property "minecraft_version_range", project.minecraft_version_range
     inputs.property "loader_version", project.loader_version
     filteringCharset "UTF-8"
 
     filesMatching("fabric.mod.json") {
         expand "version": project.version,
                 "minecraft_version": project.minecraft_version,
+                "minecraft_version_range": project.minecraft_version_range,
                 "loader_version": project.loader_version
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -47,14 +47,12 @@ dependencies {
 
 processResources {
     inputs.property "version", project.version
-    inputs.property "minecraft_version", project.minecraft_version
     inputs.property "minecraft_version_range", project.minecraft_version_range
     inputs.property "loader_version", project.loader_version
     filteringCharset "UTF-8"
 
     filesMatching("fabric.mod.json") {
         expand "version": project.version,
-                "minecraft_version": project.minecraft_version,
                 "minecraft_version_range": project.minecraft_version_range,
                 "loader_version": project.loader_version
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,14 +3,14 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.21.1
-yarn_mappings=1.21.1+build.3
+minecraft_version=1.21.4
+yarn_mappings=1.21.4+build.4
 loader_version=0.16.9
 
-fabric_version=0.110.0+1.21.1
+fabric_version=0.113.0+1.21.4
 
 # Mod Properties
-mod_version=0.1.0+1.21.1
+mod_version=0.1.0+1.21.4
 maven_group=org.scubakay
 archives_base_name=dynamic-resource-pack
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ loader_version=0.16.9
 fabric_version=0.113.0+1.21.4
 
 # Mod Properties
-mod_version=0.1.1+1.21
+mod_version=0.1.0+1.21
 maven_group=org.scubakay
 archives_base_name=dynamic-resource-pack
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ loader_version=0.16.9
 fabric_version=0.113.0+1.21.4
 
 # Mod Properties
-mod_version=0.1.0+1.21.4
+mod_version=0.1.1+1.21.4
 maven_group=org.scubakay
 archives_base_name=dynamic-resource-pack
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,13 +4,14 @@ org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
 minecraft_version=1.21.4
+minecraft_version_range=^1.21
 yarn_mappings=1.21.4+build.4
 loader_version=0.16.9
 
 fabric_version=0.113.0+1.21.4
 
 # Mod Properties
-mod_version=0.1.1+1.21.4
+mod_version=0.1.1+1.21
 maven_group=org.scubakay
 archives_base_name=dynamic-resource-pack
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
 minecraft_version=1.21.4
-minecraft_version_range=^1.21
+minecraft_version_range=~1.21
 yarn_mappings=1.21.4+build.4
 loader_version=0.16.9
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -20,6 +20,6 @@
   "depends": {
     "fabricloader": ">=${loader_version}",
     "fabric": "*",
-    "minecraft": "${minecraft_version}"
+    "minecraft": "${minecraft_version_range}"
   }
 }


### PR DESCRIPTION
I've found that this mod works fine on all current versions of 1.21, so this changes fabric.mod.json to allow it.

The main target version is set to 1.21.4, and with testing the builds do work on earlier versions. It can be changed back to 1.21.1 without consequence I believe, if you want.

Since this is messing with gradle stuff, I bumped its version to the latest patch for 8.11 (8.11.1). Gradle is on 8.12 right now but I don't think that matters really