### PR TITLE
Fix file watcher double trigger bug

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,11 +1,8 @@
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-
 plugins {
     `maven-publish`
     id("fabric-loom")
     //id("dev.kikugie.j52j")
     id("me.modmuss50.mod-publish-plugin")
-    id("com.github.johnrengelman.shadow") version "8.1.1"
 }
 
 class ModData {
@@ -36,12 +33,11 @@ group = mod.group
 base { archivesName.set(mod.id) }
 
 loom {
-    splitEnvironmentSourceSets()
+    serverOnlyMinecraftJar()
 
     mods {
         create("template") {
             sourceSet(sourceSets["main"])
-            sourceSet(sourceSets["client"])
         }
     }
 }
@@ -54,11 +50,6 @@ repositories {
     strictMaven("https://www.cursemaven.com", "CurseForge", "curse.maven")
     strictMaven("https://api.modrinth.com/maven", "Modrinth", "maven.modrinth")
     strictMaven("https://maven.maxhenkel.de/repository/public", "MaxHenkel")
-}
-
-val shadowLibrary: Configuration by configurations.creating {
-    isCanBeResolved = true
-    isCanBeConsumed = false
 }
 
 dependencies {
@@ -105,18 +96,6 @@ java {
     val java = if (stonecutter.eval(mcVersion, ">=1.20.6")) JavaVersion.VERSION_21 else JavaVersion.VERSION_17
     targetCompatibility = java
     sourceCompatibility = java
-}
-
-tasks.named<ShadowJar>("shadowJar") {
-    configurations = listOf(shadowLibrary)
-    archiveClassifier = "dev-shadow"
-    relocate("de.maxhenkel.admiral", "com.scubakay.autorelog.admiral")
-}
-
-tasks {
-    remapJar {
-        inputFile = shadowJar.get().archiveFile
-    }
 }
 
 tasks.processResources {

--- a/file_reload_test.bat
+++ b/file_reload_test.bat
@@ -3,8 +3,9 @@ REM Simulate an in-place overwrite (like IntelliJ) by toggling resource-pack and
 
 echo Toggling resource-pack and resource-pack-sha1 lines in server.properties...
 
+REM Write to a temp file, then atomically replace server.properties in one action
 powershell -NoProfile -Command ^
-    "$lines = Get-Content \"run\server.properties\"; " ^
+    "$lines = Get-Content 'run/server.properties'; " ^
     "$out = foreach ($line in $lines) { " ^
     "    if ($line -match '^resource-pack=(.+)$') { '# resource-pack=' + $Matches[1] } " ^
     "    elseif ($line -match '^# resource-pack=(.+)$') { 'resource-pack=' + $Matches[1] } " ^
@@ -12,6 +13,7 @@ powershell -NoProfile -Command ^
     "    elseif ($line -match '^# resource-pack-sha1=(.+)$') { 'resource-pack-sha1=' + $Matches[1] } " ^
     "    else { $line } " ^
     "}; " ^
-    "$out | Set-Content \"run\server.properties\""
+    "$tmp = [System.IO.Path]::GetTempFileName(); $out | Set-Content $tmp; " ^
+    "Move-Item -Force $tmp 'run/server.properties'"
 
 echo Done.

--- a/file_reload_test.bat
+++ b/file_reload_test.bat
@@ -1,0 +1,17 @@
+@echo off
+REM Simulate an in-place overwrite (like IntelliJ) by toggling resource-pack and resource-pack-sha1 lines directly
+
+echo Toggling resource-pack and resource-pack-sha1 lines in server.properties...
+
+powershell -NoProfile -Command ^
+    "$lines = Get-Content \"run\server.properties\"; " ^
+    "$out = foreach ($line in $lines) { " ^
+    "    if ($line -match '^resource-pack=(.+)$') { '# resource-pack=' + $Matches[1] } " ^
+    "    elseif ($line -match '^# resource-pack=(.+)$') { 'resource-pack=' + $Matches[1] } " ^
+    "    elseif ($line -match '^resource-pack-sha1=(.+)$') { '# resource-pack-sha1=' + $Matches[1] } " ^
+    "    elseif ($line -match '^# resource-pack-sha1=(.+)$') { 'resource-pack-sha1=' + $Matches[1] } " ^
+    "    else { $line } " ^
+    "}; " ^
+    "$out | Set-Content \"run\server.properties\""
+
+echo Done.

--- a/src/main/java/org/scubakay/dynamic_resource_pack/util/ConfigFileHandler.java
+++ b/src/main/java/org/scubakay/dynamic_resource_pack/util/ConfigFileHandler.java
@@ -74,7 +74,6 @@ public class ConfigFileHandler {
     private void onConfigFileChange() {
         ServerProperties newConfig = loadServerProperties();
         if (!newConfig.equals(serverProperties)) {
-            DynamicResourcePack.LOGGER.info("{} has changed, reloading resource pack...", getConfigFile(server).getFileName());
             serverProperties = newConfig;
 
             if (DynamicResourcePack.modConfig.runReloadOnResourcePackUpdate.get()) {


### PR DESCRIPTION
Quick and dirty solution is to add a delay between the file change and trying to load the config with config-builder.

Close #7 